### PR TITLE
Maybe use `cscope` and build `ctags` and `cscope` db automatically?

### DIFF
--- a/home/.config/nvim/init.vim
+++ b/home/.config/nvim/init.vim
@@ -75,10 +75,13 @@ set statusline+=%#warningmsg#
 set statusline+=%{SyntasticStatuslineFlag()}
 set statusline+=%*
 
+"" Make tag jumping use cscope files, if possible
+set cscopetag
+
+
 "" Configure `ctrlpvim/ctrlp.vim`
 let g:ctrlp_switch_buffer="ETVH"
-let g:ctrlp_working_path_mode='rca'
-let g:ctrlp_root_markers= ['tags', '.ctrlp']
+let g:ctrlp_working_path_mode='wca'
 
 "" Make `netrw` display in tree mode...
 let g:netrw_liststyle=3

--- a/home/.git-template/hooks/ctags
+++ b/home/.git-template/hooks/ctags
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+
+function git-dir () {
+  git rev-parse --git-dir
+}
+
+local WORKFILE="$(git-dir)/$$.tags"
+
+trap 'rm -f "$WORKFILE"' EXIT
+git ls-files "$@" \
+  | ctags --tag-relative -L - -f "$WORKFILE" \
+&& mv "$WORKFILE" "${WORKFILE/$$\.}"

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -85,3 +85,5 @@
 [grep]
 	lineNumber = true
 	extendedRegexp = true
+[init]
+	templateDir = /home/al_the_x/.git-template

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -84,3 +84,4 @@
 	prune = true
 [grep]
 	lineNumber = true
+	extendedRegexp = true

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -39,6 +39,9 @@ run '~/.tmux/plugins/tpm/tpm'
 # set the command prefix to match gnuscreen (i.e. CTRL+a)
 set-option -g prefix C-a
 
+# start window indexes with 1 because 0 is SO FAR AWAY...
+set-option -g base-index 1
+
 # set the current window name to a nice bold yellow text
 set-window-option -g window-status-current-attr bold
 set-window-option -g window-status-current-fg yellow

--- a/home/.tmux.keys.conf
+++ b/home/.tmux.keys.conf
@@ -9,3 +9,7 @@ bind-key '"' command-prompt "rename-window %%"; unbind-key ','
 
 # because I regularly get screen-size locked by zombie sessions
 bind-key C-x attach -d
+
+# Set by copycat for IDK!?!?
+unbind-key -n N
+unbind-key -n n

--- a/home/.zshalias
+++ b/home/.zshalias
@@ -51,13 +51,6 @@ function wtf {
 }
 
 
-## Exec the `node` repl with `rlwrap` if available...
-function node {
-  [[ $# -eq 0 ]] && whence rlwrap &> /dev/null && {
-    NODE_NO_READLINE=1 rlwrap node
-  } || node "$@"
-}
-
 ##
 # My primary CASTLE is named `dotfiles`
 ##


### PR DESCRIPTION
- [ ] Link to blog post by `@tpope` that inspired this.
- [ ] Write a blog post to explain this insanity... for me, mostly.
- [ ] Test `~/.git-template/hooks/ctags` in an existing repo
- [ ] Set `git config --global core.hooksDirectory` to point to `~/.git-template/hooks`
- [ ] Make sure that doesn't break `husky`... or just install `husky` hooks in the same place?
- [ ] Update `Brewfile` to include `ctags` for new installs
- [ ] Update `~/.git-template/hooks/ctags` to run `Starscope` instead?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/al-the-x/dotfiles/7)
<!-- Reviewable:end -->
